### PR TITLE
Small css update

### DIFF
--- a/iitc-offle.user.js
+++ b/iitc-offle.user.js
@@ -283,7 +283,7 @@ function wrapper(plugin_info) {
                 font-family: monospace;
                 text-align: center;
                 text-shadow: 0 0 0.5em black, 0 0 0.5em black, 0 0 0.5em black;
-                pointer-events: none;
+                pointer-events: none!important;
                 -webkit-text-size-adjust: none;
             }
             `)


### PR DESCRIPTION
For some reason you can't click to activate a portal when offle keys layer is available. The !important tag seems to fix it